### PR TITLE
Add mariadb-connector-c package for MariaDB compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,7 @@ RUN set -xe; \
         libxslt \
         make \
         mariadb-client \
+        mariadb-connector-c \
         nano \
         openssh \
         openssh-client \


### PR DESCRIPTION
The mariadb-connector-c package is required when using the mysql2 gem & DB adapter in combination with a MariaDB database.

I ran into this error when trying to run a Ruby on Rails server without the package installed.
```
Unable to load application: LoadError: Error loading shared library libmariadb.so.3: No such file or directory (needed by /usr/local/bundle/gems/mysql2-0.5.3/lib/mysql2/mysql2.so) - /usr/local/bundle/gems/mysql2-0.5.3/lib/mysql2/mysql2.so
```