### PR TITLE
Pass Docker repo to Docker Compose file when running make test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ buildx-push:
 
 test:
 ifneq ($(RUBY_DEV),)
-	cd ./tests && RUBY_TAG=$(TAG) ./run.sh
+	cd ./tests && RUBY_IMAGE=$(REPO):$(TAG) ./run.sh
 else
 	@echo "We run tests only for DEV images."
 endif

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,6 +1,6 @@
-ARG RUBY_TAG
+ARG RUBY_IMAGE
 
-FROM wodby/ruby:${RUBY_TAG}
+FROM $RUBY_IMAGE
 
 RUN gem install rails
 

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     build:
       context: ./
       args:
-        RUBY_TAG: $RUBY_TAG
+        RUBY_IMAGE: $RUBY_IMAGE
     environment:
       SSH_DISABLE_STRICT_KEY_CHECKING: 1
       DEBUG: 1
@@ -43,7 +43,7 @@ services:
     build:
       context: ./
       args:
-        RUBY_TAG: $RUBY_TAG
+        RUBY_IMAGE: $RUBY_IMAGE
     command: sudo /usr/sbin/sshd -De
     volumes:
     - ./authorized_keys:/home/wodby/.ssh/authorized_keys
@@ -54,7 +54,7 @@ services:
     build:
       context: ./
       args:
-        RUBY_TAG: $RUBY_TAG
+        RUBY_IMAGE: $RUBY_IMAGE
     command: sudo -E crond -f -d 0
     volumes:
       - ./crontab:/etc/crontabs/wodby


### PR DESCRIPTION
Follow up to [PR4](https://github.com/wodby/ruby/pull/4). This removes the hardcoded repo & image name in the tests.