### PR TITLE
Add gcompat to dev packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,6 +78,7 @@ RUN set -xe; \
     if [[ -n "${RUBY_DEV}" ]]; then \
         apk add --update --no-cache -t .wodby-ruby-dev-deps \
             build-base \
+            gcompat \
             imagemagick-dev \
             libffi-dev \
             linux-headers \


### PR DESCRIPTION
The widely used [tailwindcss-rails gem requires gcompat](https://github.com/rails/tailwindcss-rails#install-gnu-libc-compatibility) to be installed.